### PR TITLE
武器名の16進カラーコードが正しく表示されるようにする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,6 @@ buildNumber.properties
 .classpath
 
 # End of https://www.toptal.com/developers/gitignore/api/intellij+all,maven
+
+# Visual Studio Code
+.vscode/

--- a/src/main/java/net/azisaba/lgw/core/utils/Chat.java
+++ b/src/main/java/net/azisaba/lgw/core/utils/Chat.java
@@ -11,7 +11,18 @@ public class Chat {
 
     // メッセージをフォーマットして、&で色をつける
     public static String f(String text, Object... args) {
-        return MessageFormat.format(ChatColor.translateAlternateColorCodes('&', text), args);
+
+        // String型の引数は装飾コードを適用する
+        Object[] formattedArgs = new Object[args.length];
+        for(int i = 0; i < args.length; i++) {
+            if (args[i] instanceof String) {
+                formattedArgs[i] = f(ChatColor.translateAlternateColorCodes('&', args[i].toString()));
+            }
+            else {
+                formattedArgs[i] = args[i];
+            }
+        }
+        return MessageFormat.format(ChatColor.translateAlternateColorCodes('&', text), formattedArgs);
     }
 
     // 色を消す


### PR DESCRIPTION
`Chat#f`によるフォーマット時、文字列型の引数にも装飾コードを適用するようにした
※武器名以外の部分で`Chat#f`を使用している部分も影響するが、動作として正しく表示されるようになるため未チェック